### PR TITLE
Remove all CrossOrigin annotations from ReusabilityController

### DIFF
--- a/src/main/java/gr/zisis/reusabilityapi/controller/ReusabilityController.java
+++ b/src/main/java/gr/zisis/reusabilityapi/controller/ReusabilityController.java
@@ -25,25 +25,21 @@ public class ReusabilityController {
     @Autowired
     private ReusabilityService reusabilityService;
 
-    @CrossOrigin(origins = "*")
     @GetMapping(value = "/reusabilityIndexByCommit")
     Collection<FileReusabilityIndex> getReusabilityIndexByCommit(@RequestParam(required = true) String url, @RequestParam(required = true) String sha, @RequestParam(required = false) Integer limit) {
         return Objects.nonNull(limit) ? reusabilityService.findReusabilityIndexByCommit(url, sha, limit) : reusabilityService.findReusabilityIndexByCommit(url, sha, null);
     }
 
-    @CrossOrigin(origins = "*")
     @GetMapping(value = "/reusabilityIndexByCommitAndFile")
     Collection<FileReusabilityIndex> getReusabilityIndexByCommitAndFile(@RequestParam(required = true) String url, @RequestParam(required = true) String sha, @RequestParam(required = true) String filePath) {
         return reusabilityService.findReusabilityIndexByCommitAndFile(url, sha, filePath);
     }
 
-    @CrossOrigin(origins = "*")
     @GetMapping(value = "/projectReusabilityIndexByCommit")
     Collection<ProjectReusabilityIndex> getProjectReusabilityIndexByCommit(@RequestParam(required = true) String url, @RequestParam(required = true) String sha) {
         return reusabilityService.findProjectReusabilityIndexByCommit(url, sha);
     }
 
-    @CrossOrigin(origins = "*")
     @GetMapping(value = "/projectReusabilityIndexPerCommit")
     Collection<ProjectReusabilityIndex> getProjectReusabilityIndexPerCommit(@RequestParam(required = true) String url, @RequestParam(required = false) Integer limit) {
         return reusabilityService.findProjectReusabilityIndexPerCommit(url, limit);


### PR DESCRIPTION
All CORS configurations should be removed, as they are being handled by the SmartCLIDE API Gateway.